### PR TITLE
add megaboom to exempt list

### DIFF
--- a/list-repos
+++ b/list-repos
@@ -36,6 +36,7 @@ REJECT_MATCHES = [
   Regexp.new("^helm-dm$"),
   Regexp.new("^informant$"),
   Regexp.new("^makeself$"),
+  Regexp.new("^megaboom"),
   Regexp.new("^memkv$"),
   Regexp.new("^minio-src$"),
   Regexp.new("^minio-sync$"),


### PR DESCRIPTION
megaboom is a fork and does not have issues enabled so it cannot create issue labels.
