### PR TITLE
chore(seed-repo): update workflow milestones for monthly releases

### DIFF
--- a/seed-repo
+++ b/seed-repo
@@ -114,11 +114,11 @@ MILESTONES = {
     },
     "v2.9" => {
       state: "open",
-      due_on: Time.parse("November 9, 2016").utc,
+      due_on: Time.parse("December 1, 2016").utc,
     },
     "v2.10" => {
       state: "open",
-      due_on: Time.parse("November 23, 2016").utc,
+      due_on: Time.parse("January 5, 2016").utc,
     },
   }
 }


### PR DESCRIPTION
See deis/workflow#586.

Questions:
- Assuming this policy is accepted, is it ok to skip the November 9 (bi-weekly) release and sync up starting December 1? Or should we move the v2.9 milestone to (first Thursday) November 10 and go monthly from there?
