### PR TITLE
ref(list-repos): remove docker-go-dev from blacklist

### DIFF
--- a/list-repos
+++ b/list-repos
@@ -28,7 +28,6 @@ REJECT_MATCHES = [
   Regexp.new("^deis\.io$"),
   Regexp.new("^django-fsm$"),
   Regexp.new("^django-polls$"),
-  Regexp.new("^docker-go-dev$"),
   Regexp.new("^docker-go-test$"),
   Regexp.new("^docker-python-dev$"),
   Regexp.new("^docker-registry$"),


### PR DESCRIPTION
This image is mainly used for Workflow components, so it only makes sense for it to have all the
relevant milestones and labels for triaging.